### PR TITLE
PS-27: New evaluatePatientSummaryTemplate with EvaluationContext param.

### DIFF
--- a/api/src/main/java/org/openmrs/module/patientsummary/api/PatientSummaryService.java
+++ b/api/src/main/java/org/openmrs/module/patientsummary/api/PatientSummaryService.java
@@ -17,9 +17,10 @@ import java.util.List;
 import java.util.Map;
 
 import org.openmrs.api.OpenmrsService;
-import org.openmrs.module.patientsummary.PatientSummaryTemplate;
 import org.openmrs.module.patientsummary.PatientSummaryReportDefinition;
 import org.openmrs.module.patientsummary.PatientSummaryResult;
+import org.openmrs.module.patientsummary.PatientSummaryTemplate;
+import org.openmrs.module.reporting.evaluation.EvaluationContext;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -75,7 +76,16 @@ public interface PatientSummaryService extends OpenmrsService {
 	public List<PatientSummaryTemplate> getAllPatientSummaryTemplates(boolean includeRetired);
 	
 	/**
-	 * @return the resulting patient summary result from evaluating the passed patient summary template for the given patient and parameters
+	 * @return the resulting patient summary result from evaluating the passed patient summary
+	 *         template for the given patient and EvaluationContext instance
+	 */
+	@Transactional(readOnly = true)
+	public PatientSummaryResult evaluatePatientSummaryTemplate(PatientSummaryTemplate patientSummaryTemplate,
+	        Integer patientId, EvaluationContext context);
+	
+	/**
+	 * @return the resulting patient summary result from evaluating the passed patient summary
+	 *         template for the given patient and parameters
 	 */
 	@Transactional(readOnly = true)
 	public PatientSummaryResult evaluatePatientSummaryTemplate(PatientSummaryTemplate patientSummaryTemplate, Integer patientId, Map<String, Object> parameters);

--- a/api/src/main/java/org/openmrs/module/patientsummary/api/PatientSummaryServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/patientsummary/api/PatientSummaryServiceImpl.java
@@ -136,24 +136,18 @@ public class PatientSummaryServiceImpl extends BaseOpenmrsService implements Pat
 		return l;
 	}
 	
-	/**
-	 * @see PatientSummaryService#evaluatePatientSummaryTemplate(PatientSummaryTemplate, Integer, Map)
-	 */
 	@Override
-	public PatientSummaryResult evaluatePatientSummaryTemplate(PatientSummaryTemplate patientSummaryTemplate, Integer patientId, Map<String, Object> parameters) {
-		PatientSummaryResult result = new PatientSummaryResult(patientSummaryTemplate, patientId, parameters);
+	public PatientSummaryResult evaluatePatientSummaryTemplate(PatientSummaryTemplate patientSummaryTemplate,
+	        Integer patientId, EvaluationContext context) {
+		PatientSummaryResult result = new PatientSummaryResult(patientSummaryTemplate, patientId,
+		        context.getParameterValues());
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		try {
 			// Populate a new EvaluationContext with the patient and parameters passed in
-			EvaluationContext context = new EvaluationContext();
 			Cohort baseCohort = new Cohort();
 			baseCohort.addMember(patientId);
 			context.setBaseCohort(baseCohort);
-			if (parameters != null) {
-				for (Map.Entry<String, Object> paramEntry : parameters.entrySet()) {
-					context.addParameterValue(paramEntry.getKey(), paramEntry.getValue());
-				}
-			}
+			//parameters can be set on EvaluationContext instance before passing it into this method
 			
 			// Evaluate the PatientSummary with this Context to produce data, then
 			// use that data to populate the summary
@@ -177,6 +171,26 @@ public class PatientSummaryServiceImpl extends BaseOpenmrsService implements Pat
 		finally {
 			IOUtils.closeQuietly(baos);
 		}
+		return result;
+		
+	}
+	
+	/**
+	 * @see PatientSummaryService#evaluatePatientSummaryTemplate(PatientSummaryTemplate, Integer,
+	 *      Map)
+	 */
+	@Override
+	public PatientSummaryResult evaluatePatientSummaryTemplate(PatientSummaryTemplate patientSummaryTemplate,
+	        Integer patientId, Map<String, Object> parameters) {
+		EvaluationContext context = new EvaluationContext();
+		if (parameters != null) {
+			for (Map.Entry<String, Object> paramEntry : parameters.entrySet()) {
+				context.addParameterValue(paramEntry.getKey(), paramEntry.getValue());
+			}
+		}
+		
+		PatientSummaryResult result = evaluatePatientSummaryTemplate(patientSummaryTemplate, patientId, context);
+		
 		return result;
 	}
 	

--- a/api/src/test/java/org/openmrs/module/patientsummary/PatientSummaryBehaviorTest.java
+++ b/api/src/test/java/org/openmrs/module/patientsummary/PatientSummaryBehaviorTest.java
@@ -36,6 +36,7 @@ import org.openmrs.module.reporting.data.person.definition.ObsForPersonDataDefin
 import org.openmrs.module.reporting.data.person.definition.PreferredAddressDataDefinition;
 import org.openmrs.module.reporting.data.person.definition.PreferredNameDataDefinition;
 import org.openmrs.module.reporting.dataset.definition.PatientDataSetDefinition;
+import org.openmrs.module.reporting.evaluation.context.EncounterEvaluationContext;
 import org.openmrs.test.BaseModuleContextSensitiveTest;
 
 /**
@@ -80,6 +81,7 @@ public class PatientSummaryBehaviorTest extends BaseModuleContextSensitiveTest {
 		rd = pss.savePatientSummaryReportDefinition(rd);
 		
 		PatientSummaryTestUtil.testGroovyTemplate(rd, 7, "Encounters");
+		PatientSummaryTestUtil.testGroovyTemplateWithContext(rd, 7, "Encounters", new EncounterEvaluationContext());
 	}
 	
 	//@Test
@@ -106,6 +108,7 @@ public class PatientSummaryBehaviorTest extends BaseModuleContextSensitiveTest {
 		rd = pss.savePatientSummaryReportDefinition(rd);
 		
 		PatientSummaryTestUtil.testGroovyTemplate(rd, 7, "Obs");//TODO Fails: http://pastebin.com/uSBYd9hs
+		PatientSummaryTestUtil.testGroovyTemplateWithContext(rd, 7, "Obs", new EncounterEvaluationContext());//TODO Fails: http://pastebin.com/uSBYd9hs
 	}
 	
 	//@Test
@@ -126,7 +129,8 @@ public class PatientSummaryBehaviorTest extends BaseModuleContextSensitiveTest {
 		
 		rd = pss.savePatientSummaryReportDefinition(rd);
 		
-		PatientSummaryTestUtil.testGroovyTemplate(rd, 7, "Alert");//TODO Error: http://pastebin.com/khAQLY9u
+		PatientSummaryTestUtil.testGroovyTemplate(rd, 7, "Alert");//TODO Error: http://pastebin.com/khAQLY9
+		PatientSummaryTestUtil.testGroovyTemplateWithContext(rd, 7, "Alert", new EncounterEvaluationContext());//TODO Error: http://pastebin.com/khAQLY9u
 	}
 	
 	private PatientSummaryService getService() {
@@ -157,6 +161,7 @@ public class PatientSummaryBehaviorTest extends BaseModuleContextSensitiveTest {
 		saveObs(7, "2012-02-01", 7, 18);
 		
 		PatientSummaryTestUtil.testGroovyTemplate(rd, 7, "ObsBasedProblemList");
+		PatientSummaryTestUtil.testGroovyTemplateWithContext(rd, 7, "ObsBasedProblemList", new EncounterEvaluationContext());
 	}
 	
 	private void saveObs(Integer personId, String dateStr, Integer question, Integer answer) {
@@ -189,5 +194,6 @@ public class PatientSummaryBehaviorTest extends BaseModuleContextSensitiveTest {
 		rd = pss.savePatientSummaryReportDefinition(rd);
 		
 		PatientSummaryTestUtil.testGroovyTemplate(rd, 7, "LastThreeObs");//TODO Fix: http://pastebin.com/MkD9Cxht
+		PatientSummaryTestUtil.testGroovyTemplateWithContext(rd, 7, "LastThreeObs", new EncounterEvaluationContext());//TODO Fix: http://pastebin.com/MkD9Cxht
 	}
 }

--- a/api/src/test/java/org/openmrs/module/patientsummary/PatientSummaryTestUtil.java
+++ b/api/src/test/java/org/openmrs/module/patientsummary/PatientSummaryTestUtil.java
@@ -22,6 +22,7 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.patientsummary.api.PatientSummaryService;
+import org.openmrs.module.reporting.evaluation.EvaluationContext;
 import org.openmrs.module.reporting.report.ReportDesign;
 import org.openmrs.module.reporting.report.ReportDesignResource;
 import org.openmrs.module.reporting.report.renderer.TextTemplateRenderer;
@@ -51,6 +52,24 @@ public class PatientSummaryTestUtil {
 		Assert.assertEquals(StringUtils.deleteWhitespace(expectedResults), StringUtils.deleteWhitespace(actualResult));
 	}
 
+	/**
+	 * Utility method that tests that the results of evaluating a particular template,
+	 * for a particular report definition, produces a particular result
+	 */
+	public static void testGroovyTemplateWithContext(PatientSummaryReportDefinition rd, Integer patientId, String templatePrefix, EvaluationContext context) throws Exception {
+
+		PatientSummaryTemplate template = createGroovyTemplate("Test", rd, "templates/" + templatePrefix + "Template.txt");
+		String expectedResults = PatientSummaryTestUtil.getResourceAsString("templates/" + templatePrefix + "Output.txt");
+
+		PatientSummaryService pss = Context.getService(PatientSummaryService.class);
+		PatientSummaryResult result = pss.evaluatePatientSummaryTemplate(template, patientId, context);
+
+		Assert.assertNull(result.getErrorDetails());
+		String actualResult = new String(result.getRawContents(), "UTF-8");
+		Assert.assertEquals(StringUtils.deleteWhitespace(expectedResults), StringUtils.deleteWhitespace(actualResult));
+	}
+
+	
 	/**
 	 * Utility method to retrieve a text-based resource as a String
 	 */


### PR DESCRIPTION
JIRA Ticket:
https://issues.openmrs.org/browse/PS-27

Purpose:
adding additional PatientSummaryService API method allowing user to pass in an EvaluationContext that has already be initialized, instead of just a parameter map

Testing:
All tests now have both the original API call and the call to the new API method using a new blank EncounterEvaluationContext to verify they still all work identically to calling the existing method.