### PR TITLE
TRUNK-5722: Removed application context reference to DefaultAnnotationHandlerMapping.

### DIFF
--- a/omod/src/main/resources/webModuleApplicationContext.xml
+++ b/omod/src/main/resources/webModuleApplicationContext.xml
@@ -21,7 +21,6 @@
   		    http://www.springframework.org/schema/util/spring-util-3.0.xsd">
 
 
-	<bean class="org.springframework.web.servlet.mvc.annotation.DefaultAnnotationHandlerMapping"/>	
 	<context:component-scan base-package="org.openmrs.module.patientsummary.web.controller" />
  	
 </beans>


### PR DESCRIPTION
#### Ticket:
https://issues.openmrs.org/browse/TRUNK-5722

#### What I have done:
Removed this from web module application context:
```xml
<bean class="org.springframework.web.servlet.mvc.annotation.DefaultAnnotationHandlerMapping"/>
```